### PR TITLE
Fix Logic Pro detection (11/12/Creator Studio), quit crash, and duplicate presence

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -101,7 +101,6 @@ void logic_pro_loop(std::shared_ptr<discordpp::Client> client) {
                 }
             } else {
                 activity.SetState("Browsing projects");
-                activity.SetDetails("Logic Pro");
             }
 
             // Add assets for better RPC display
@@ -317,6 +316,6 @@ int app_main() {
 
     std::cout << "👋 Shutting down...\n";
     config::save();
-    if (logic_thread.joinable()) logic_thread.join();
+    // Do not join logic_thread here — engine::stop() already joins it. Double-join causes SIGABRT on quit.
     return 0;
 }

--- a/logiccheck.mm
+++ b/logiccheck.mm
@@ -5,14 +5,32 @@
 bool is_logic_pro_running();
 
 #import <AppKit/NSRunningApplication.h>
+#import <AppKit/NSWorkspace.h>
 
 //function changed from .cpp to .mm to use NSString ->
 bool is_logic_pro_running() {
     @autoreleasepool {
-        NSString* bundleId = @"com.apple.logic10";
-        NSArray<NSRunningApplication*>* apps =
-            [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleId];
-        return (apps.count > 0);
+        // Known bundle IDs: Logic 10 (logic10), Logic 11 (logic11), Mac App Store (logicpro), Logic 12 / Creator Studio (music.apps.logic)
+        NSArray<NSString*>* bundleIds = @[
+            @"com.apple.logic10",
+            @"com.apple.logic11",
+            @"com.apple.logicpro",
+            @"com.apple.music.apps.logic"
+        ];
+        for (NSString* bundleId in bundleIds) {
+            NSArray<NSRunningApplication*>* apps =
+                [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleId];
+            if (apps.count > 0)
+                return true;
+        }
+        // Fallback: match by app name (handles unknown/future bundle IDs)
+        NSString* targetName = @"Logic Pro";
+        for (NSRunningApplication* app in [[NSWorkspace sharedWorkspace] runningApplications]) {
+            NSString* name = app.localizedName;
+            if (name && [name isEqualToString:targetName])
+                return true;
+        }
+        return false;
     }
 }
 


### PR DESCRIPTION
**Logic Pro detection (logiccheck.mm)**
- Support bundle IDs: `com.apple.logic11`, `com.apple.logicpro`, `com.apple.music.apps.logic` (Logic 12 / Creator Studio)
- Fallback: detect by app name "Logic Pro" when bundle ID is unknown

**Quit crash (app.cpp)**
- Remove `logic_thread.join()` from `app_main()` — `engine::stop()` already joins it. Double-join caused SIGABRT when quitting from the menu.

**Rich presence (app.cpp)**
- When browsing (no project open), stop setting Details to "Logic Pro" so the activity card doesn’t show the app name twice.